### PR TITLE
Chromium - fix ungoogled-chromium key installation

### DIFF
--- a/docs/chromium.rst
+++ b/docs/chromium.rst
@@ -88,7 +88,8 @@ Ungoogled Chromium
 .. code-block:: bash
 
 	echo 'deb http://download.opensuse.org/repositories/home:/ungoogled_chromium/Ubuntu_Focal/ /' | sudo tee /etc/apt/sources.list.d/home:ungoogled_chromium.list
-	sudo wget -nv https://download.opensuse.org/repositories/home:ungoogled_chromium/Ubuntu_Focal/Release.key -O "/etc/apt/trusted.gpg.d/home:ungoogled_chromium.asc"
+	wget -nv https://download.opensuse.org/repositories/home:ungoogled_chromium/Ubuntu_Focal/Release.key -O /tmp/home:ungoogled_chromium.asc
+	sudo apt-key add /tmp/home:ungoogled_chromium.asc
 	apt update
 	apt remove --purge chromium-browser
 	apt install ungoogled-chromium


### PR DESCRIPTION
Hi,

The instructions from https://software.opensuse.org/download/package?package=ungoogled-chromium&project=home:ungoogled_chromium allow ungoogled-chromium to be installed but the signing key isn't properly installed - i.e. it doesn't get listed as a key in Software Sources that can be removed etc.

The alternative command provided by this PR does integrate the key fully.