### PR TITLE
Buster apt pinning - refined instructions

### DIFF
--- a/docs/chromium.rst
+++ b/docs/chromium.rst
@@ -101,7 +101,7 @@ APT pinning consists in pointing to repositories which are not designed for Linu
 Debian Buster
 -------------
 
-As root, add the following to `/etc/apt/sources.list.d/debian-chromium.list`
+As root, add the following to `/etc/apt/sources.list.d/z-debian-chromium.list`
 
 .. code-block:: text
 
@@ -109,29 +109,29 @@ As root, add the following to `/etc/apt/sources.list.d/debian-chromium.list`
 	deb https://deb.debian.org/debian buster-updates main
 	deb http://security.debian.org/ buster/updates main
 
-And the following to `/etc/apt/preferences.d/debian-chromium.pref`
+And the following to `/etc/apt/preferences.d/z-debian-chromium.pref`
 
 .. code-block:: text
 
 	# Don't install anything other than chromium from the Debian repos
 	Package: *
 	Pin: origin "deb.debian.org"
-	Pin-Priority: 1
+	Pin-Priority: -10
 
 	# Don't install anything other than chromium from the Debian repos
 	Package: *
 	Pin: origin "security.debian.org"
-	Pin-Priority: 1
+	Pin-Priority: -10
 
 	# Exclude the game chromium-bsu
 	Package: chromium-bsu*
 	Pin: origin "deb.debian.org"
-	Pin-Priority: 1
+	Pin-Priority: -10
 
 	# Exclude the game chromium-bsu
 	Package: chromium-bsu*
 	Pin: origin "security.debian.org"
-	Pin-Priority: 1
+	Pin-Priority: -10
 
 	# Pattern includes 'chromium'
 	Package: chromium*
@@ -142,6 +142,16 @@ And the following to `/etc/apt/preferences.d/debian-chromium.pref`
 	Package: chromium*
 	Pin: origin "security.debian.org"
 	Pin-Priority: 700
+
+	# Chromium dependencies only in buster
+	Package: /libevent-2.1-6/ /libicu63/ /libjpeg62-turbo/ /libvpx5/
+	Pin: origin "deb.debian.org"
+	Pin-Priority: 1
+
+	# Chromium dependencies only in buster
+	Package: /libevent-2.1-6/ /libicu63/ /libjpeg62-turbo/ /libvpx5/
+	Pin: origin "security.debian.org"
+	Pin-Priority: 1
 
 Then run the following commands:
 


### PR DESCRIPTION
Hi,

* Renames the `debian-chromium.list` to `z-debian-chromium.list` and `debian-chromium.pref `to `z-debian-chromium.pref`
This avoids the issue where packages with the same name and version in both buster and focal are incorrectly flagged as being installed from buster and are reported as candidates for downgrade to the focal version - https://github.com/linuxmint/doc-user-guide/issues/1

* Changes the default pinning rule to -10. This avoids users being able to install other non chromium related packages that are only in the Buster repos and not in the Focal repos.

* Add some additional rules for chromium dependencies that are only available in Buster.

Supersedes https://github.com/linuxmint/doc-user-guide/pull/4
