### PR TITLE
Disable timeshift, without breaking it

### DIFF
--- a/docs/upgrade-to-mint-20.rst
+++ b/docs/upgrade-to-mint-20.rst
@@ -188,7 +188,7 @@ If you're using another snapshot tool and would rather not use Timeshift, you ca
 
 .. code-block:: bash
 
-	sudo touch /etc/timeshift.json
+	echo "{}" | sudo tee /etc/timeshift.json
 
 Don't forget to remove that file after the upgrade if you want Timeshift to work properly.
 


### PR DESCRIPTION
It seems that if the timeshift.json file isn't JSON it will crash timeshift if the user later trys to use it.