### PR TITLE
Restore PDF and ePub downloads

### DIFF
--- a/.readthedocs.yaml
+++ b/.readthedocs.yaml
@@ -5,6 +5,11 @@
 # Required
 version: 2
 
+# Build PDF & ePub
+formats:
+  - epub
+  - pdf
+
 # Set the version of Python and other tools you might need
 build:
   os: ubuntu-22.04


### PR DESCRIPTION
The docs used to be available as PDF and ePub downloads, useful for people needing offline access. I guess since the new .readthedocs.yaml they are not created. To restore them, adding the formats setting.